### PR TITLE
Added detail in deployment script

### DIFF
--- a/tasks/deployers/nftStake.ts
+++ b/tasks/deployers/nftStake.ts
@@ -7,7 +7,7 @@ task("deploy:NFTStake")
   .addParam("nft", "The NFT Contract Address")
   .addParam("erc20", "The payout ERC20 Token")
   .addParam("dao", "The DAO which governs the contract")
-  .addParam("reward", "ERC20 tokens rewarded per block")
+  .addParam("reward", "ERC20 tokens rewarded per block per account")
   .setAction(async function (taskArguments: TaskArguments, { ethers }) {
     const nftStakeFactory: NftStake__factory = await ethers.getContractFactory("NftStake");
     const nftStake: NftStake = <NftStake>(


### PR DESCRIPTION
To be clear the `emissionRate` variable refers to the emission per account, as the [reward](https://github.com/dopedao/contracts/blob/73a01777f4d5cea5eca06f16efd78a95384e6b96/contracts/NftStake.sol#L145) is being calculated per account.